### PR TITLE
Removed overflow hidden when fully expanded

### DIFF
--- a/dist/ng-slide-down.js
+++ b/dist/ng-slide-down.js
@@ -70,7 +70,8 @@
           });
           if (emitOnClose || onClose || lazyRender) {
             return closePromise = $timeout(function () {
-              if (emitOnClose) {
+              element.css("overflow", "inital");
+			  if (emitOnClose) {
                 scope.$emit(emitOnClose, {});
               }
               if (onClose) {

--- a/src/ng-slide-down.coffee
+++ b/src/ng-slide-down.coffee
@@ -54,6 +54,7 @@ angular.module("ng-slide-down", []).directive "ngSlideDown", ($timeout )->
       }
       if emitOnClose || onClose || lazyRender
         closePromise = $timeout ()->
+          element.css("overflow", "inital")
           scope.$emit emitOnClose, {} if emitOnClose
           elementScope.$eval(onClose) if onClose
           scope.lazyRender = false if lazyRender


### PR DESCRIPTION
This is so that the widget doesn't interfere with the contents when it shouldn't, without any additional overheads. 
This allows the user to dynamically add content and handle how the overflow operates themselves.
